### PR TITLE
Review linear-doc

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1073,8 +1073,8 @@ en:
   linear_row_comment_basePrice: It will be used to compare with the value of <code>stop_px</code>, to decide whether your conditional order will be triggered by crossing trigger price from upper side or lower side. Mainly used to identify the expected direction of the current conditional order.
   linear_row_comment_stopPx: Trigger price
 
-  linear_set_auto_add_margin: Set auto add margin
-  linear_account_para_setAutoAddMargin: Set auto add margin
+  linear_set_auto_add_margin: Set Auto Add Margin
+  linear_account_para_setAutoAddMargin: Set auto add margin, or <a href="https://help.bybit.com/hc/en-us/articles/900000394403-Introduction-to-Auto-Margin-Replenishment-USDT-Contract-">Auto-Margin Replenishment</a>.
   linear_row_comment_set_auto_margin: Auto add margin button
 
   linear_set_leverage: Set Leverage

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1087,7 +1087,7 @@ en:
 
   linearAddMargin: Add Margin
   linear_account_para_addMargin: Add Margin
-  linear_account_row_comment_margin: Add/Remove how much margin<span>:</span> Increase 10; decrease -10, Support 4 decimal places
+  linear_account_row_comment_margin: Add/Remove how much margin<span>:</span> Increase 10; decrease -10, supports 4 decimal places
   ### websocket
   linear_websocket_para_endpoint: |
     Base endpoints:
@@ -1131,9 +1131,9 @@ en:
   linear_order_fix_order_type___20200403: Fix value of <code>order_type</code> in response
   linear_prve_funding: My Last Funding Fee
   linear_exec_type: Execution type
-  linear_closed_pnl: Closed profit and loss
+  closedprofitandloss: Closed Profit and Loss
   linear_add_margin: Add/Reduce Margin
   restapi_update_20200414: Updated <code>BTCUSDT</code> contract information
   linear_private_trade_records: Get user's trading records. The results are ordered in descending order (the first item is the latest).
-  linear_private_closed_pnl_records: Get user's cloded profit and loss records. The results are ordered in descending order (the first item is the latest).
-  linear_row_comment_limit: Limit for data size per page, max size is 50. Default as showing 20 pieces of data per page. Max 50 limit per page
+  linear_private_closed_pnl_records: Get user's closed profit and loss records. The results are ordered in descending order (the first item is the latest).
+  linear_row_comment_limit: Limit for data size per page, max size is 50. Default as showing 20 pieces of data per page.

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1110,7 +1110,7 @@ zh-cn:
   linear_order_fix_order_type___20200403: 修复市价单order_type显示值
   linear_prve_funding: 查询上个周期资金费用结算信息
   linear_exec_type: 交易类型
-  linear_closed_pnl: 平仓盈亏
+  closedprofitandloss: 平仓盈亏
   linear_add_margin: 增加/减少保证金
   restapi_update_20200414: 更新 <code>BTCUSDT</code> 合约信息
   linear_private_trade_records: 获取用户成交记录，按时间降序排列。

--- a/source/includes/inverse_future/_changelog.md
+++ b/source/includes/inverse_future/_changelog.md
@@ -37,7 +37,7 @@
 
 ## 2020-02-26
 ### REST API
-- [t(:placev2active)](#t-placev2active) 
+- [t(:placev2active)](#t-placev2active)
     - t(:update_20200226)
 
 ## 2020-02-10

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -186,7 +186,7 @@ t(:account_aside_cancelAllActive)
 
 #### t(:httprequest)
 POST
-<code><span id=vpoCancelAll>private/linear/order/cancel-all</span></code>
+<code><span id=vpoCancelAll>/private/linear/order/cancel-all</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCancelAll"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
 #### t(:requestparameters)
@@ -441,7 +441,7 @@ POST
     "ext_info": "",
     "result": [
         "89a38056-80f1-45b2-89d3-4d8e3a203a79",  
-        "89a38056-80f1-45b2-89d3-4d8e3a203a79", 
+        "89a38056-80f1-45b2-89d3-4d8e3a203a79",
     ],
     "time_now": "1577454993.799912",
     "rate_limit_status": 90,

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -868,12 +868,12 @@ t(:linear_private_trade_records)
 t(:wallet_aside_tradeRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+#### t(:httprequest)
 GET
 <code><span id=vpeList>/private/linear/trade/execution/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpeList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+#### t(:requestparameters)
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:misc_row_comment_symbolNotOrderId) |
@@ -952,8 +952,8 @@ t(:wallet_aside_tradeRecords)
 
 #### t(:httprequest_wallet)
 GET
-<code><span id=vpeList>/private/linear/trade/closed-pnl/list</span></code>
-<button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpeList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
+<code><span id=pltcList>/private/linear/trade/closed-pnl/list</span></code>
+<button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pltcList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
 #### t(:requestparameters_wallet)
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -902,7 +902,7 @@ GET
 
 
 
-### t(:linear_closed_pnl)
+### t(:closedprofitandloss)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -7,7 +7,7 @@
 - [t(:tradingstop)](#t-tradingstop) [t(:changelog_new)]
 - [t(:linear_add_margin)](#t-linear_add_margin) [t(:changelog_new)]
 - [t(:usertraderecords)](#t-usertraderecords) [t(:changelog_new)]
-- [t(:linear_closed_pnl)](#t-linear_closed_pnl) [t(:changelog_new)]
+- [t(:closedprofitandloss)](#t-closedprofitandloss) [t(:changelog_new)]
 - [t(:getrisklimit)](#t-getrisklimit) [t(:changelog_new)]
 
 


### PR DESCRIPTION
I'll submit another PR later which will refactor the linear doc to match the inverse, eg `linear_recent_trading_records` to `publictradingrecords`.