### PR TITLE
Refactor endpoints to fix URLs

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1073,7 +1073,7 @@ en:
   linear_row_comment_basePrice: It will be used to compare with the value of <code>stop_px</code>, to decide whether your conditional order will be triggered by crossing trigger price from upper side or lower side. Mainly used to identify the expected direction of the current conditional order.
   linear_row_comment_stopPx: Trigger price
 
-  linear_set_auto_add_margin: Set Auto Add Margin
+  setautoaddmargin: Set Auto Add Margin
   linear_account_para_setAutoAddMargin: Set auto add margin, or <a href="https://help.bybit.com/hc/en-us/articles/900000394403-Introduction-to-Auto-Margin-Replenishment-USDT-Contract-">Auto-Margin Replenishment</a>.
   linear_row_comment_set_auto_margin: Auto add margin button
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1123,7 +1123,7 @@ en:
   ## change-log
   linear_update_20200331: <code>order_status</code> field not support query orders with specific statuses
   linear_update_20200331_ws_ob: fix response data bug
-  linear_recent_trading_records: Public Trading Records
+  publictradingrecords: Public Trading Records
   linear_prev_funding_rate: Get the Last Funding Rate
   linear_kline_row_comment_limit_200: Limit for data size, max size is 200. Default as showing 200 pieces of data
   linear_order___20200403: Add field <code>reduce_only</code> in response

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -235,7 +235,7 @@ en:
   ## Active Orders
   activeorders: Active Orders
   ### Place Active Order V2
-  placev2active: Place Active Order V2
+  placeactive: Place Active Order V2
   account_para_placeActive: |
     <p>Market price active order: A traditional market price order which will be filled at the best available price. <code>price</code> is not required for this type of order.</p>
     <p>Limit price active order: You can set an execution price for your order. Only when the last traded price reaches the order price will the system will fill your order.</p>
@@ -252,7 +252,7 @@ en:
   account_row_comment_orderId: Order ID
   account_row_comment_orderStatus: Query your orders for all statuses if 'order_status' is empty. If you want to query orders with specific statuses, you can pass the order_status split by ','.
   ### Cancel Active Order V2
-  cancelv2active: Cancel Active Order V2
+  cancelactive: Cancel Active Order V2
   account_para_cancelActive: |
     <p>Either <code>order_id</code> or <code>order_link_id</code> are required for cancelling active orders. <code>order_id</code> - this unique 36 characters order ID was returned to you when the active order was created successfully.</p>
     <p>You may cancel active orders that are unfilled or partially filled. Fully filled orders cannot be cancelled.</p>
@@ -331,7 +331,7 @@ en:
   ## Position
   position: Position
   ### My Position V2 (real-time)
-  mypositionv2: My Position V2 (real-time)
+  myposition: My Position V2 (real-time)
   account_para_myPosition: Get my position list.
   ### Change Margin
   changemargin: Change Margin
@@ -1054,14 +1054,14 @@ en:
   err_130127: Take Profit, Stop Loss and Trailing Stop Loss are not modified
 
   ### LinearPosition
-  mypositionv2: My Position
+  myposition: My Position
 
   ### Linear Cancel Active Order
-  cancelv2active: Cancel Active Order
+  cancelactive: Cancel Active Order
   linear_row_comment_qty: Order quantity in USD.
   linear_row_comment_reduceOnly: <a href="https://help.bybit.com/hc/en-us/articles/360039260574-What-is-a-reduce-only-order-"> What is a reduce-only order?</a> True means your position can only reduce in size if this order is triggered
   linear_row_comment_closeOnTrigger: <a href="https://help.bybit.com/hc/en-us/articles/360039260534-What-is-a-close-on-trigger-Order-">  What is a close on trigger order?</a> For a closing order. It can only reduce your position, not increase it. If the account has insufficient available balance when the closing order is triggered, then other active orders of similar contracts will be cancelled or reduced. It can be used to ensure your stop loss reduces your position regardless of current available margin.
-  placev2active: Place Active Order
+  placeactive: Place Active Order
   linear_account_para_placeActive: |
     <p>Market price active order: A traditional market price order which will be filled at the best available price. <code>price</code> is not required for this type of order.</p>
     <p>Limit price active order: You can set an execution price for your order. Only when the last traded price reaches the order price will the system will fill your order.</p>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1057,7 +1057,7 @@ en:
   linear_position: My Position
 
   ### Linear Cancel Active Order
-  linear_cancel_active: Cancel Active Order
+  cancelv2active: Cancel Active Order
   linear_row_comment_qty: Order quantity in USD.
   linear_row_comment_reduceOnly: <a href="https://help.bybit.com/hc/en-us/articles/360039260574-What-is-a-reduce-only-order-"> What is a reduce-only order?</a> True means your position can only reduce in size if this order is triggered
   linear_row_comment_closeOnTrigger: <a href="https://help.bybit.com/hc/en-us/articles/360039260534-What-is-a-close-on-trigger-Order-">  What is a close on trigger order?</a> For a closing order. It can only reduce your position, not increase it. If the account has insufficient available balance when the closing order is triggered, then other active orders of similar contracts will be cancelled or reduced. It can be used to ensure your stop loss reduces your position regardless of current available margin.

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1061,7 +1061,7 @@ en:
   linear_row_comment_qty: Order quantity in USD.
   linear_row_comment_reduceOnly: <a href="https://help.bybit.com/hc/en-us/articles/360039260574-What-is-a-reduce-only-order-"> What is a reduce-only order?</a> True means your position can only reduce in size if this order is triggered
   linear_row_comment_closeOnTrigger: <a href="https://help.bybit.com/hc/en-us/articles/360039260534-What-is-a-close-on-trigger-Order-">  What is a close on trigger order?</a> For a closing order. It can only reduce your position, not increase it. If the account has insufficient available balance when the closing order is triggered, then other active orders of similar contracts will be cancelled or reduced. It can be used to ensure your stop loss reduces your position regardless of current available margin.
-  linear_place_active: Place Active Order
+  placev2active: Place Active Order
   linear_account_para_placeActive: |
     <p>Market price active order: A traditional market price order which will be filled at the best available price. <code>price</code> is not required for this type of order.</p>
     <p>Limit price active order: You can set an execution price for your order. Only when the last traded price reaches the order price will the system will fill your order.</p>

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -604,7 +604,7 @@ en:
   ## How to Subscribe to Topics
   subscribe: How to Subscribe to Topics
   ### Understanding Websocket Filters
-  websocket_filters: Understanding Websocket Filters
+  websocketfilters: Understanding Websocket Filters
   websocket_codequote_filters1: How to subscribe with a filter
   websocket_codequote_filters2: How to subscribe with multiple filters
   websocket_codequote_filters3: How to subscribe without filters

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1132,7 +1132,7 @@ en:
   linear_prve_funding: My Last Funding Fee
   linear_exec_type: Execution type
   closedprofitandloss: Closed Profit and Loss
-  linear_add_margin: Add/Reduce Margin
+  addmargin: Add/Reduce Margin
   restapi_update_20200414: Updated <code>BTCUSDT</code> contract information
   linear_private_trade_records: Get user's trading records. The results are ordered in descending order (the first item is the latest).
   linear_private_closed_pnl_records: Get user's closed profit and loss records. The results are ordered in descending order (the first item is the latest).

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1124,7 +1124,7 @@ en:
   linear_update_20200331: <code>order_status</code> field not support query orders with specific statuses
   linear_update_20200331_ws_ob: fix response data bug
   publictradingrecords: Public Trading Records
-  linear_prev_funding_rate: Get the Last Funding Rate
+  fundingrate: Get the Last Funding Rate
   linear_kline_row_comment_limit_200: Limit for data size, max size is 200. Default as showing 200 pieces of data
   linear_order___20200403: Add field <code>reduce_only</code> in response
   linear_poistion___20200403: Add field <code>free_qty</code> in response

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1081,7 +1081,7 @@ en:
   linear_account_para_setLeverage: Set Leverage
   linear_row_comment_leverage: Must be greater than 0 and less than the <a href="https://help.bybit.com/hc/en-us/articles/360039749753-What-is-Risk-Limit-What-effect-does-the-Risk-Limit-have-on-Margin-Inverse-Contract-">risk limit leverage</a>.
 
-  linear_switch_isolated: Cross/Isolated margin switch
+  marginswitch: Cross/Isolated Margin Switch
   linear_account_para_switchIsolated: Switch Cross/Isolated; must be leverage value when switching from Cross to Isolated
   linear_row_comment_switch_isolated: Cross/Isolated<span>:</span> true is Isolated; false is Cross
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1077,7 +1077,7 @@ en:
   linear_account_para_setAutoAddMargin: Set auto add margin, or <a href="https://help.bybit.com/hc/en-us/articles/900000394403-Introduction-to-Auto-Margin-Replenishment-USDT-Contract-">Auto-Margin Replenishment</a>.
   linear_row_comment_set_auto_margin: Auto add margin button
 
-  linear_set_leverage: Set Leverage
+  setleverage: Set Leverage
   linear_account_para_setLeverage: Set Leverage
   linear_row_comment_leverage: Must be greater than 0 and less than the <a href="https://help.bybit.com/hc/en-us/articles/360039749753-What-is-Risk-Limit-What-effect-does-the-Risk-Limit-have-on-Margin-Inverse-Contract-">risk limit leverage</a>.
 

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1054,7 +1054,7 @@ en:
   err_130127: Take Profit, Stop Loss and Trailing Stop Loss are not modified
 
   ### LinearPosition
-  linear_position: My Position
+  mypositionv2: My Position
 
   ### Linear Cancel Active Order
   cancelv2active: Cancel Active Order

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -1129,7 +1129,7 @@ en:
   linear_order___20200403: Add field <code>reduce_only</code> in response
   linear_poistion___20200403: Add field <code>free_qty</code> in response
   linear_order_fix_order_type___20200403: Fix value of <code>order_type</code> in response
-  linear_prve_funding: My Last Funding Fee
+  mylastfundingfee: My Last Funding Fee
   linear_exec_type: Execution type
   closedprofitandloss: Closed Profit and Loss
   addmargin: Add/Reduce Margin

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1029,7 +1029,7 @@ zh-cn:
   err_130127: 止盈止损及追踪止损没有修改
 
   ### LinearPosition
-  linear_position: 获取持仓（实时）
+  mypositionv2: 获取持仓（实时）
 
   ### Linear Cancel Active Order
   cancelv2active: 取消活动委托订单

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -597,7 +597,7 @@ zh-cn:
   ## How to Subscribe to Topics
   subscribe: 订阅方式
   ### Understanding Websocket Filters
-  websocket_filters: Websocket订阅方式
+  websocketfilters: Websocket订阅方式
   websocket_codequote_filters1: 直接订阅
   websocket_codequote_filters2: 通过分隔符来订阅多个topic
   websocket_codequote_filters3: 通过匹配符来订阅多个topic

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1108,7 +1108,7 @@ zh-cn:
   linear_order___20200403: 返回值中增加参数 <code>reduce_only</code>
   linear_poistion___20200403: 增加可平量参数<code>free_qty</code>
   linear_order_fix_order_type___20200403: 修复市价单order_type显示值
-  linear_prve_funding: 查询上个周期资金费用结算信息
+  mylastfundingfee: 查询上个周期资金费用结算信息
   linear_exec_type: 交易类型
   closedprofitandloss: 平仓盈亏
   addmargin: 增加/减少保证金

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1059,7 +1059,7 @@ zh-cn:
   linear_account_para_setLeverage: 设置杠杆
   linear_row_comment_leverage: <code>杠杆大于0，小于风险限额对应的杠杆</code>
 
-  linear_switch_isolated: 全仓/逐仓切换
+  marginswitch: 全仓/逐仓切换
   linear_account_para_switchIsolated: 全仓/逐仓切换，从全仓切换至逐仓时需要传杠杆
   linear_row_comment_switch_isolated: 全仓/逐仓, true是逐仓，false是全仓
 

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1051,7 +1051,7 @@ zh-cn:
   linear_row_comment_basePrice: 当前市价。用于和stop_px值进行比较，确定当前条件委托是看空到<code>stop_px</code>时触发还是看多到stop_px触发。主要是用来标识当前条件单预期的方向
   linear_row_comment_stopPx: 条件委托下单时市价
 
-  linear_set_auto_add_margin: 自动追加保证金
+  setautoaddmargin: 自动追加保证金
   linear_account_para_setAutoAddMargin: 设置自动追加保证金。
   linear_row_comment_set_auto_margin: 追加保证金开关
 

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1111,7 +1111,7 @@ zh-cn:
   linear_prve_funding: 查询上个周期资金费用结算信息
   linear_exec_type: 交易类型
   closedprofitandloss: 平仓盈亏
-  linear_add_margin: 增加/减少保证金
+  addmargin: 增加/减少保证金
   restapi_update_20200414: 更新 <code>BTCUSDT</code> 合约信息
   linear_private_trade_records: 获取用户成交记录，按时间降序排列。
   linear_private_closed_pnl_records: 获取用户平仓记录，按时间降序排列。

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1102,7 +1102,7 @@ zh-cn:
   ## change-log
   linear_update_20200331: <code>order_status</code> 参数不再支持多条件查询。
   linear_update_20200331_ws_ob: 修复orderBook更新包数据错乱的问题
-  linear_recent_trading_records: 平台最近交易历史数据
+  publictradingrecords: 平台最近交易历史数据
   linear_prev_funding_rate: 查询上个周期的资金费率
   linear_kline_row_comment_limit_200: 最大200. 默认每页200条
   linear_order___20200403: 返回值中增加参数 <code>reduce_only</code>

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1032,7 +1032,7 @@ zh-cn:
   linear_position: 获取持仓（实时）
 
   ### Linear Cancel Active Order
-  linear_cancel_active: 取消活动委托订单
+  cancelv2active: 取消活动委托订单
 
   linear_row_comment_qty: 委托数量
   linear_row_comment_reduceOnly: 是否平仓单,true-平仓 false-开仓

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1055,7 +1055,7 @@ zh-cn:
   linear_account_para_setAutoAddMargin: 设置自动追加保证金。
   linear_row_comment_set_auto_margin: 追加保证金开关
 
-  linear_set_leverage: 设置杠杆
+  setleverage: 设置杠杆
   linear_account_para_setLeverage: 设置杠杆
   linear_row_comment_leverage: <code>杠杆大于0，小于风险限额对应的杠杆</code>
 

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1037,7 +1037,7 @@ zh-cn:
   linear_row_comment_qty: 委托数量
   linear_row_comment_reduceOnly: 是否平仓单,true-平仓 false-开仓
   linear_row_comment_closeOnTrigger: 平仓委托,只会减少您的仓位而不会增加您的仓位。如果当平仓委托被触发时，账户上的余额不足，那么该合约的其他委托将被取消或者降低委托数量。使用此选项可以确保您的止损单被用于减仓而非加仓。
-  linear_place_active: 创建活动委托单
+  placev2active: 创建活动委托单
   linear_account_para_placeActive: |
     <p>市价活动委托: 一个传统的市场价格订单,会以当前的最优价格为您成交订单。当且仅当选择市价单时，<code>price</code>可为空！</p>
     <p>限价活动委托: 您可以为您的订单设置一个执行价格，当市场价格达到您的设置价格时，系统会为您成交订单。</p>

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1103,7 +1103,7 @@ zh-cn:
   linear_update_20200331: <code>order_status</code> 参数不再支持多条件查询。
   linear_update_20200331_ws_ob: 修复orderBook更新包数据错乱的问题
   publictradingrecords: 平台最近交易历史数据
-  linear_prev_funding_rate: 查询上个周期的资金费率
+  fundingrate: 查询上个周期的资金费率
   linear_kline_row_comment_limit_200: 最大200. 默认每页200条
   linear_order___20200403: 返回值中增加参数 <code>reduce_only</code>
   linear_poistion___20200403: 增加可平量参数<code>free_qty</code>

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -228,7 +228,7 @@ zh-cn:
   ## Active Orders
   activeorders: 活动单
   ### Place Active Order V2
-  placev2active: 创建活动委托单
+  placeactive: 创建活动委托单
   account_para_placeActive: |
     <p>市价活动委托: 一个传统的市场价格订单,会以当前的最优价格为您成交订单。当且仅当选择市价单时，<code>price</code>可为空！</p>
     <p>限价活动委托: 您可以为您的订单设置一个执行价格，当市场价格达到您的设置价格时，系统会为您成交订单。</p>
@@ -246,7 +246,7 @@ zh-cn:
   account_row_comment_orderId: 订单ID
   account_row_comment_orderStatus: 指定订单状态查询订单列表。不传该参数则默认查询所有状态订单。该参数支持多状态查询，状态之间用英文逗号分割。
   ### Cancel Active Order V2
-  cancelv2active: 撤销活动委托单
+  cancelactive: 撤销活动委托单
   account_para_cancelActive: |
     <p>所有撤销活动委托都必须填写<code>order_id</code>或<code>order_link_id</code>。 <code>order_id</code> - 当您成功创建了活动委托时会为您返回36位唯一的订单ID。</p>
     <p>您可以撤销未成交、部分成交的活动委托单。但全部成交的活动委托不可取消。</p>
@@ -318,7 +318,7 @@ zh-cn:
   ## Position
   position: 持仓
   ### My Position V2 (real-time)
-  mypositionv2: 获取持仓（实时）
+  myposition: 获取持仓（实时）
   account_para_myPosition: 获取我的仓位列表。通过该接口可以获取当前用户的持仓信息，如持仓数量、账户余额等信息
   ### Change Margin
   changemargin: 更新保证金
@@ -1029,15 +1029,15 @@ zh-cn:
   err_130127: 止盈止损及追踪止损没有修改
 
   ### LinearPosition
-  mypositionv2: 获取持仓（实时）
+  myposition: 获取持仓（实时）
 
   ### Linear Cancel Active Order
-  cancelv2active: 取消活动委托订单
+  cancelactive: 取消活动委托订单
 
   linear_row_comment_qty: 委托数量
   linear_row_comment_reduceOnly: 是否平仓单,true-平仓 false-开仓
   linear_row_comment_closeOnTrigger: 平仓委托,只会减少您的仓位而不会增加您的仓位。如果当平仓委托被触发时，账户上的余额不足，那么该合约的其他委托将被取消或者降低委托数量。使用此选项可以确保您的止损单被用于减仓而非加仓。
-  placev2active: 创建活动委托单
+  placeactive: 创建活动委托单
   linear_account_para_placeActive: |
     <p>市价活动委托: 一个传统的市场价格订单,会以当前的最优价格为您成交订单。当且仅当选择市价单时，<code>price</code>可为空！</p>
     <p>限价活动委托: 您可以为您的订单设置一个执行价格，当市场价格达到您的设置价格时，系统会为您成交订单。</p>

--- a/source/includes/inverse_future/_account_data.md
+++ b/source/includes/inverse_future/_account_data.md
@@ -2,7 +2,7 @@
 t(:account_para)
 
 ## t(:activeorders)
-### t(:placev2active)
+### t(:placeactive)
 > t(:codequote_responseExample)
 
 ```javascript
@@ -134,7 +134,7 @@ GET
 |<a href="#order-status-order_status-get">order_status</a> |false |string |t(:account_row_comment_orderStatus) |
 
 
-### t(:cancelv2active)
+### t(:cancelactive)
 > t(:codequote_responseExample)
 
 ```javascript
@@ -787,7 +787,7 @@ POST
 
 
 ## t(:position)
-### t(:mypositionv2)
+### t(:myposition)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/inverse_future/_changelog.md
+++ b/source/includes/inverse_future/_changelog.md
@@ -37,7 +37,7 @@
 
 ## 2020-02-26
 ### REST API
-- [t(:placev2active)](#t-placev2active)
+- [t(:placeactive)](#t-placeactive)
     - t(:update_20200226)
 
 ## 2020-02-10
@@ -62,7 +62,7 @@
 ## 2019-12-18
 
 ### REST API
-- [t(:mypositionv2)](#t-mypositionv2) [t(:changelog_new)]
+- [t(:myposition)](#t-myposition) [t(:changelog_new)]
 
 ### Websocket API
 - [t(:websocketorderbook200)](#t-websocketorderbook200) [t(:changelog_new)]
@@ -77,8 +77,8 @@
 ## 2019-12-02
 
 ### REST API
-- [t(:placev2active)](#t-placev2active) [t(:changelog_new)]
-- [t(:cancelv2active)](#t-cancelv2active) [t(:changelog_new)]
+- [t(:placeactive)](#t-placeactive) [t(:changelog_new)]
+- [t(:cancelactive)](#t-cancelactive) [t(:changelog_new)]
 - [t(:cancelallactive)](#t-cancelallactive) [t(:changelog_new)]
 - [t(:cancelallcond)](#t-cancelallcond) [t(:changelog_new)]
 
@@ -102,7 +102,7 @@
 
 ### REST API
 - [t(:announcement)](#t-announcement) [t(:changelog_new)]
-- [t(:cancelOrder_20191104)](#t-cancelv2active) [t(:changelog_update)]
+- [t(:cancelOrder_20191104)](#t-cancelactive) [t(:changelog_update)]
     - t(:cancelOrder__20191104)
 - [t(:cancelcond)](#t-cancelcond) [t(:changelog_update)]
     - t(:cancelCond__20191104)

--- a/source/includes/inverse_future/_websockets.md
+++ b/source/includes/inverse_future/_websockets.md
@@ -81,7 +81,7 @@ t(:websocket_para_limit)
 
 
 ## t(:subscribe)
-### t(:websocket_filters)
+### t(:websocketfilters)
 > t(:websocket_codequote_filters1)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -122,7 +122,7 @@ GET
 |<a href="#order-status-order_status-get">order_status</a> |false |string |t(:linear_account_row_comment_orderStatus) |
 
 
-### t(:linear_cancel_active)
+### t(:cancelv2active)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -1239,7 +1239,7 @@ GET
 
 
 ## t(:funding)
-### t(:linear_prve_funding)
+### t(:mylastfundingfee)
 > t(:codequote_curlExample)
 
 ```console

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -663,7 +663,7 @@ POST
 
 
 
-### t(:linear_switch_isolated)
+### t(:marginswitch)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -763,7 +763,7 @@ POST
 
 
 
-### t(:linear_add_margin)
+### t(:addmargin)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -533,7 +533,7 @@ GET
 
 
 ## t(:position)
-### t(:linear_position)
+### t(:mypositionv2)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -629,7 +629,7 @@ POST
 |auto_add_margin |true |bool |t(:linear_row_comment_set_auto_margin)  |
 
 
-### t(:linear_set_leverage)
+### t(:setleverage)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -597,7 +597,7 @@ GET
 
 
 
-### t(:linear_set_auto_add_margin)
+### t(:setautoaddmargin)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -2,7 +2,7 @@
 t(:account_para)
 
 ## t(:activeorders)
-### t(:linear_place_active)
+### t(:placev2active)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -2,7 +2,7 @@
 t(:account_para)
 
 ## t(:activeorders)
-### t(:placev2active)
+### t(:placeactive)
 > t(:codequote_responseExample)
 
 ```javascript
@@ -122,7 +122,7 @@ GET
 |<a href="#order-status-order_status-get">order_status</a> |false |string |t(:linear_account_row_comment_orderStatus) |
 
 
-### t(:cancelv2active)
+### t(:cancelactive)
 > t(:codequote_responseExample)
 
 ```javascript
@@ -533,7 +533,7 @@ GET
 
 
 ## t(:position)
-### t(:mypositionv2)
+### t(:myposition)
 > t(:codequote_responseExample)
 
 ```javascript

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -3,7 +3,7 @@
 ## 2020-04-14
 ### REST API
 - [t(:linear_prve_funding)](#t-linear_prve_funding) [t(:changelog_new)]
-- [t(:linear_set_auto_add_margin)](#t-linear_set_auto_add_margin) [t(:changelog_new)]
+- [t(:setautoaddmargin)](#t-setautoaddmargin) [t(:changelog_new)]
 - [t(:tradingstop)](#t-tradingstop) [t(:changelog_new)]
 - [t(:linear_add_margin)](#t-linear_add_margin) [t(:changelog_new)]
 - [t(:usertraderecords)](#t-usertraderecords) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -2,7 +2,7 @@
 
 ## 2020-04-14
 ### REST API
-- [t(:linear_prve_funding)](#t-linear_prve_funding) [t(:changelog_new)]
+- [t(:mylastfundingfee)](#t-mylastfundingfee) [t(:changelog_new)]
 - [t(:setautoaddmargin)](#t-setautoaddmargin) [t(:changelog_new)]
 - [t(:tradingstop)](#t-tradingstop) [t(:changelog_new)]
 - [t(:addmargin)](#t-addmargin) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -31,7 +31,7 @@
 - [t(:queryactive)](#t-queryactive) [t(:changelog_update)]
     - t(:linear_order___20200403)
     - t(:linear_order_fix_order_type___20200403)
-- [t(:linear_position)](#t-position) [t(:changelog_update)]
+- [t(:mypositionv2)](#t-position) [t(:changelog_update)]
     - t(:linear_poistion___20200403)
 
 ## 2020-03-31
@@ -50,7 +50,7 @@
 ## 2020-03-27
 ### REST API
 - [t(:placev2active)](#t-activeorders) [t(:changelog_new)]
-- [t(:linear_position)](#t-position) [t(:changelog_new)]
+- [t(:mypositionv2)](#t-position) [t(:changelog_new)]
 
 ### Websocket API
 - [t(:websocketorderbook25)](#t-websocketorderbook25) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -22,7 +22,7 @@
 - [t(:querykline)](#t-querykline) [t(:changelog_new)]
 - [t(:publictradingrecords)](#t-publictradingrecords) [t(:changelog_new)]
 - [t(:fundingrate)](#t-fundingrate) [t(:changelog_new)]
-- [t(:placev2active)](#t-placev2active) [t(:changelog_update)]
+- [t(:placeactive)](#t-placeactive) [t(:changelog_update)]
     - t(:linear_order___20200403)
     - t(:linear_order_fix_order_type___20200403)
 - [t(:getactive)](#t-getactive) [t(:changelog_update)]
@@ -31,7 +31,7 @@
 - [t(:queryactive)](#t-queryactive) [t(:changelog_update)]
     - t(:linear_order___20200403)
     - t(:linear_order_fix_order_type___20200403)
-- [t(:mypositionv2)](#t-position) [t(:changelog_update)]
+- [t(:myposition)](#t-position) [t(:changelog_update)]
     - t(:linear_poistion___20200403)
 
 ## 2020-03-31
@@ -49,8 +49,8 @@
 
 ## 2020-03-27
 ### REST API
-- [t(:placev2active)](#t-activeorders) [t(:changelog_new)]
-- [t(:mypositionv2)](#t-position) [t(:changelog_new)]
+- [t(:placeactive)](#t-activeorders) [t(:changelog_new)]
+- [t(:myposition)](#t-position) [t(:changelog_new)]
 
 ### Websocket API
 - [t(:websocketorderbook25)](#t-websocketorderbook25) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -17,7 +17,7 @@
 
 ## 2020-04-07
 ### REST API
-- [t(:linear_set_leverage)](#t-linear_set_leverage) [t(:changelog_new)]
+- [t(:setleverage)](#t-setleverage) [t(:changelog_new)]
 - [t(:linear_switch_isolated)](#t-linear_switch_isolated) [t(:changelog_new)]
 - [t(:querykline)](#t-querykline) [t(:changelog_new)]
 - [t(:publictradingrecords)](#t-publictradingrecords) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -20,7 +20,7 @@
 - [t(:linear_set_leverage)](#t-linear_set_leverage) [t(:changelog_new)]
 - [t(:linear_switch_isolated)](#t-linear_switch_isolated) [t(:changelog_new)]
 - [t(:querykline)](#t-querykline) [t(:changelog_new)]
-- [t(:linear_recent_trading_records)](#t-linear_recent_trading_records) [t(:changelog_new)]
+- [t(:publictradingrecords)](#t-publictradingrecords) [t(:changelog_new)]
 - [t(:linear_prev_funding_rate)](#t-linear_prev_funding_rate) [t(:changelog_new)]
 - [t(:linear_place_active)](#t-linear_place_active) [t(:changelog_update)]
     - t(:linear_order___20200403)

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -22,7 +22,7 @@
 - [t(:querykline)](#t-querykline) [t(:changelog_new)]
 - [t(:publictradingrecords)](#t-publictradingrecords) [t(:changelog_new)]
 - [t(:fundingrate)](#t-fundingrate) [t(:changelog_new)]
-- [t(:linear_place_active)](#t-linear_place_active) [t(:changelog_update)]
+- [t(:placev2active)](#t-placev2active) [t(:changelog_update)]
     - t(:linear_order___20200403)
     - t(:linear_order_fix_order_type___20200403)
 - [t(:getactive)](#t-getactive) [t(:changelog_update)]
@@ -49,7 +49,7 @@
 
 ## 2020-03-27
 ### REST API
-- [t(:linear_place_active)](#t-activeorders) [t(:changelog_new)]
+- [t(:placev2active)](#t-activeorders) [t(:changelog_new)]
 - [t(:linear_position)](#t-position) [t(:changelog_new)]
 
 ### Websocket API

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -18,7 +18,7 @@
 ## 2020-04-07
 ### REST API
 - [t(:setleverage)](#t-setleverage) [t(:changelog_new)]
-- [t(:linear_switch_isolated)](#t-linear_switch_isolated) [t(:changelog_new)]
+- [t(:marginswitch)](#t-marginswitch) [t(:changelog_new)]
 - [t(:querykline)](#t-querykline) [t(:changelog_new)]
 - [t(:publictradingrecords)](#t-publictradingrecords) [t(:changelog_new)]
 - [t(:fundingrate)](#t-fundingrate) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -5,7 +5,7 @@
 - [t(:linear_prve_funding)](#t-linear_prve_funding) [t(:changelog_new)]
 - [t(:setautoaddmargin)](#t-setautoaddmargin) [t(:changelog_new)]
 - [t(:tradingstop)](#t-tradingstop) [t(:changelog_new)]
-- [t(:linear_add_margin)](#t-linear_add_margin) [t(:changelog_new)]
+- [t(:addmargin)](#t-addmargin) [t(:changelog_new)]
 - [t(:usertraderecords)](#t-usertraderecords) [t(:changelog_new)]
 - [t(:closedprofitandloss)](#t-closedprofitandloss) [t(:changelog_new)]
 - [t(:getrisklimit)](#t-getrisklimit) [t(:changelog_new)]

--- a/source/includes/linear_future/_changelog.md
+++ b/source/includes/linear_future/_changelog.md
@@ -21,7 +21,7 @@
 - [t(:linear_switch_isolated)](#t-linear_switch_isolated) [t(:changelog_new)]
 - [t(:querykline)](#t-querykline) [t(:changelog_new)]
 - [t(:publictradingrecords)](#t-publictradingrecords) [t(:changelog_new)]
-- [t(:linear_prev_funding_rate)](#t-linear_prev_funding_rate) [t(:changelog_new)]
+- [t(:fundingrate)](#t-fundingrate) [t(:changelog_new)]
 - [t(:linear_place_active)](#t-linear_place_active) [t(:changelog_update)]
     - t(:linear_order___20200403)
     - t(:linear_order_fix_order_type___20200403)

--- a/source/includes/linear_future/_market_data.md
+++ b/source/includes/linear_future/_market_data.md
@@ -71,7 +71,7 @@ GET
 
 
 
-### t(:linear_recent_trading_records)
+### t(:publictradingrecords)
 > t(:codequote_curlExample)
 
 ```console

--- a/source/includes/linear_future/_market_data.md
+++ b/source/includes/linear_future/_market_data.md
@@ -119,7 +119,7 @@ GET
 
 
 
-### t(:linear_prev_funding_rate)
+### t(:fundingrate)
 > t(:codequote_curlExample)
 
 ```console

--- a/source/includes/linear_future/_websockets.md
+++ b/source/includes/linear_future/_websockets.md
@@ -81,7 +81,7 @@ t(:websocket_para_limit)
 
 
 ## t(:subscribe)
-### t(:websocket_filters)
+### t(:websocketfilters)
 > t(:websocket_codequote_filters1)
 
 ```javascript


### PR DESCRIPTION
This is the PR I promised in  #41

In the final commit, `refactor REST v2 endpoints to remove v2`, I did not refactor klineV2 to kline. Leaving this here for future reference.

This PR brings the linear doc up to the inverse standard, renaming headers like so:
https://bybit-exchange.github.io/docs/linear/#t-linear_recent_trading_records
changed to
https://bybit-exchange.github.io/docs/linear/#t-publictradingrecords