### PR TITLE
Fix doc layout

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -217,7 +217,8 @@ en:
   market_aside_orderbook: The response is in the snapshot format.
   ### Query Klne
   querykline: Query Kline
-  market_para_querykline: |
+  market_para_querykline: Get kline.
+  linear_market_para_querykline: |
     <p>Get kline.</p>
     <p>For mark price klines, see the <a href="#t-markpricekline">Mark Price Kline</a> endpoint.</p>
   ### Latest Information for Symbol

--- a/source/includes/inverse_future/_account_data.md
+++ b/source/includes/inverse_future/_account_data.md
@@ -41,12 +41,12 @@ t(:account_para)
 
 t(:account_para_placeActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpoCreate>/v2/private/order/create</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCreate"><img src="/images/copy_to_clipboard.png" height=zh5 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#side-side">side</a> |true |string |t(:row_comment_side)    |
@@ -117,12 +117,12 @@ POST
 
 t(:account_para_getActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oaoList>/open-api/order/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oaoList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |false |string |t(:account_row_comment_orderId) |
@@ -173,12 +173,12 @@ GET
 
 t(:account_para_cancelActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpoCancel>/v2/private/order/cancel</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCancel"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
@@ -230,12 +230,12 @@ t(:account_para_cancelAllActive)
 t(:account_aside_cancelAllActive)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpoCancelAll>/v2/private/order/cancelAll</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCancelAll"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string | t(:row_comment_symbol) |
@@ -265,12 +265,12 @@ t(:account_para_replaceActive)
 t(:account_aside_replaceActive)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oaoReplace>/open-api/order/replace</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oaoReplace"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |true |string |t(:row_comment_orderId) |
@@ -320,12 +320,12 @@ POST
 
 t(:account_para_queryActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpOrder>/v2/private/order</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpOrder"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |false |string | t(:misc_row_comment_orderIdNotOrderLinkId)|
@@ -387,12 +387,12 @@ t(:account_para_placeCond)
 t(:account_aside_placeCond)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oasoCreate>/open-api/stop-order/create</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoCreate"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#side-side">side</a> |true |string |t(:row_comment_side)    |
@@ -468,12 +468,12 @@ POST
 
 t(:account_para_getCond)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oasoList>/open-api/stop-order/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |stop_order_id |false |string |t(:row_comment_stopOrderId) |
@@ -521,12 +521,12 @@ GET
 
 t(:account_para_cancelCond)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oasoCancel>/open-api/stop-order/cancel</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoCancel"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|required|type | comments|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)|
@@ -604,12 +604,12 @@ t(:account_para_cancelAllCond)
 t(:account_aside_cancelAllCond)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpsoCancelAll>/v2/private/stop-order/cancelAll</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpsoCancelAll"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|required|type | comments|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)|
@@ -640,12 +640,12 @@ t(:account_para_replaceCond)
 t(:account_aside_replaceCond)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oasoReplace>/open-api/stop-order/replace</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoReplace"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |stop_order_id |true |string |t(:row_comment_stopOrderId) |
@@ -695,12 +695,12 @@ POST
 
 t(:account_para_queryConditional)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpStopOrder>/v2/private/stop-order</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpStopOrder"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -741,12 +741,12 @@ GET
 
 t(:account_para_userLeverage)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=uLeverage>/user/leverage</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#uLeverage"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 
@@ -774,12 +774,12 @@ t(:account_para_changeLeverage)
 t(:account_aside_changeLeverage)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=ulSave>/user/leverage/save</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#ulSave"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -838,12 +838,12 @@ POST
 
 t(:account_para_myPosition)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=pList>/v2/private/position/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -872,12 +872,12 @@ t(:account_para_changeMargin)
 t(:account_aside_changeMargin)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=pChangePositionMargin>/position/change-position-margin</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pChangePositionMargin"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -944,12 +944,12 @@ t(:account_para_tradingStop)
 t(:account_aside_tradingStop)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oapTradingStop>/open-api/position/trading-stop</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oapTradingStop"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -1024,12 +1024,12 @@ t(:wallet_para_getRisk)
 t(:wallet_aside_getRisk)
 </aside>
 
-#### t(:httprequest1)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawrlList>/open-api/wallet/risk-limit/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawrlList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters1)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 
@@ -1105,12 +1105,12 @@ t(:wallet_para_setRisk)
 t(:wallet_aside_getRisk)
 </aside>
 
-#### t(:httprequest1)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oawRiskLimit>/open-api/wallet/risk-limit</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawRiskLimit"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters1)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -1140,12 +1140,12 @@ POST
 
 t(:market_para_fundingRate)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oafPrevFundingRate>/open-api/funding/prev-funding-rate</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oafPrevFundingRate"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -1176,12 +1176,12 @@ GET
 
 t(:account_para_myLastFunding)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oafPrevFunding>/open-api/funding/prev-funding</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oafPrevFunding"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -1209,12 +1209,12 @@ GET
 ```
 t(:account_para_predictedFunding)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oafPredictedFunding>/open-api/funding/predicted-funding</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oafPredictedFunding"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -1257,11 +1257,11 @@ GET
 
 t(:account_para_key)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oaApiKey>/open-api/api-key</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oaApiKey"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |

--- a/source/includes/inverse_future/_api_data.md
+++ b/source/includes/inverse_future/_api_data.md
@@ -22,12 +22,12 @@ curl https://api-testnet.bybit.com/v2/public/time
 ```
 t(:api_para_time)
 
-#### t(:httprequest_api_data)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpTime>/v2/public/time</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpTime"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_api_data)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 
@@ -55,11 +55,11 @@ GET
 
 t(:api_para_announcement)
 
-#### t(:httprequest_api_data)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpAnnouncement>/v2/public/announcement</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpAnnouncement"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_api_data)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |

--- a/source/includes/inverse_future/_market_data.md
+++ b/source/includes/inverse_future/_market_data.md
@@ -94,8 +94,8 @@ t(:market_para_querykline)
 
 #### t(:httprequest)
 GET
-<code><span id=vpSymbols>/v2/public/kline/list</span></code>
-<button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpSymbols"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
+<code><span id=vpkList>/v2/public/kline/list</span></code>
+<button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpkList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
 #### t(:requestparameters)
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|

--- a/source/includes/inverse_future/_market_data.md
+++ b/source/includes/inverse_future/_market_data.md
@@ -40,12 +40,12 @@ t(:market_para_orderbook)
 t(:market_aside_orderbook)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpoL2>/v2/public/orderBook/L2</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoL2"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -92,12 +92,12 @@ curl https://api.bybit.com/v2/public/kline/list?symbol=BTCUSD&interval=1&limit=2
 
 t(:market_para_querykline)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpkList>/v2/public/kline/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpkList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -153,12 +153,12 @@ curl https://api.bybit.com/v2/public/tickers
 
 t(:market_para_symbol)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpTickers>/v2/public/tickers</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpTickers"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |false |string |t(:row_comment_symbol) |
@@ -195,12 +195,12 @@ curl https://api.bybit.com/v2/public/trading-records?symbol=BTCUSD
 
 t(:market_para_records)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpTradingRecords>/v2/public/trading-records</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpTradingRecords"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -323,11 +323,11 @@ curl https://api.bybit.com/v2/public/symbols
 
 t(:market_para_querySymbol)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpSymbols>/v2/public/symbols</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpSymbols"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |

--- a/source/includes/inverse_future/_wallet_data.md
+++ b/source/includes/inverse_future/_wallet_data.md
@@ -52,12 +52,12 @@ t(:wallet_para_walletBalance)
 t(:wallet_aside_walletBalance)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpwBalance>/v2/private/wallet/balance</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpwBalance"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#currency-currency-coin">coin</a> |true |string |t(:row_comment_coin) |
@@ -115,12 +115,12 @@ t(:wallet_para_walletRecords)
 t(:wallet_aside_walletRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawfRecords>/open-api/wallet/fund/records</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawfRecords"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |start_date |false |string |t(:row_comment_startDate) |
@@ -170,12 +170,12 @@ t(:wallet_para_withdrawRecords)
 t(:wallet_aside_withdrawRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawwList>/open-api/wallet/withdraw/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawwList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |start_date |false |string |t(:row_comment_startDate) |
@@ -237,12 +237,12 @@ t(:wallet_para_tradeRecords)
 t(:wallet_aside_tradeRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpeList>/v2/private/execution/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpeList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |false |string |t(:wallet_row_comment_orderId) |

--- a/source/includes/linear_future/_account_data.md
+++ b/source/includes/linear_future/_account_data.md
@@ -39,12 +39,12 @@ t(:account_para)
 
 t(:linear_account_para_placeActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpoCreate>/private/linear/order/create</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCreate"><img src="/images/copy_to_clipboard.png" height=zh5 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#side-side">side</a> |true |string |t(:row_comment_side)    |
@@ -105,12 +105,12 @@ POST
 
 t(:account_para_getActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oaoList>/private/linear/order/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oaoList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |false |string |t(:account_row_comment_orderId) |
@@ -143,12 +143,12 @@ GET
 
 t(:account_para_cancelActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpoCancel>/private/linear/order/cancel</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCancel"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
@@ -184,12 +184,12 @@ t(:account_para_cancelAllActive)
 t(:account_aside_cancelAllActive)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpoCancelAll>/private/linear/order/cancel-all</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoCancelAll"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string | t(:row_comment_symbol) |
@@ -234,12 +234,12 @@ POST
 
 t(:account_para_queryActive)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpOrder>/private/linear/order/search</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpOrder"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |false |string | t(:misc_row_comment_orderIdNotOrderLinkId)|
@@ -302,12 +302,12 @@ t(:account_para_placeCond)
 t(:account_aside_placeCond)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oasoCreate>/private/linear/stop-order/create</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoCreate"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#side-side">side</a> |true |string |t(:row_comment_side)    |
@@ -378,12 +378,12 @@ POST
 
 t(:account_para_getCond)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oasoList>/private/linear/stop-order/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |stop_order_id |false |string |t(:row_comment_stopOrderId) |
@@ -416,12 +416,12 @@ GET
 
 t(:account_para_cancelCond)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=oasoCancel>/private/linear/stop-order/cancel</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oasoCancel"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|required|type | comments|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)|
@@ -455,12 +455,12 @@ t(:account_para_cancelAllCond)
 t(:account_aside_cancelAllCond)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=vpsoCancelAll>/private/linear/stop-order/cancel-all</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpsoCancelAll"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|required|type | comments|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)|
@@ -500,12 +500,12 @@ POST
 
 t(:account_para_queryConditional)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpStopOrder>/private/linear/stop-order/search</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpStopOrder"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -584,12 +584,12 @@ GET
 
 t(:account_para_myPosition)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=pList>/private/linear/position/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -615,12 +615,12 @@ GET
 
 t(:linear_account_para_setAutoAddMargin)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=pSetAutoAddMargin>/private/linear/position/set-auto-add-margin</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pSetAutoAddMargin"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -647,12 +647,12 @@ POST
 
 t(:linear_account_para_setLeverage)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=pSetLeverage>/private/linear/position/set-leverage</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pSetLeverage"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -693,12 +693,12 @@ t(:linear_account_para_switchIsolated)
 
 
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=pSwitchIsolated>/private/linear/position/switch-isolated</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pSwitchIsolated"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol)    |
@@ -730,12 +730,12 @@ t(:account_para_tradingStop)
 t(:account_aside_tradingStop)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=pSetTpSlTs>/private/linear/position/trading-stop</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pSetTpSlTs"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -801,12 +801,12 @@ POST
 t(:linear_account_para_addMargin)
 
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 POST
 <code><span id=pAddMargin>/private/linear/position/add-margin</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pAddMargin"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -868,12 +868,12 @@ t(:linear_private_trade_records)
 t(:wallet_aside_tradeRecords)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpeList>/private/linear/trade/execution/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpeList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -950,12 +950,12 @@ t(:linear_private_closed_pnl_records)
 t(:wallet_aside_tradeRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=pltcList>/private/linear/trade/closed-pnl/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#pltcList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -1204,12 +1204,12 @@ t(:wallet_para_getRisk)
 t(:wallet_aside_getRisk)
 </aside>
 
-#### t(:httprequest1)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawrlList>/public/linear/risk-limit</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawrlList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters1)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 
@@ -1271,12 +1271,12 @@ curl https://api.bybit.com/private/linear/funding/prev-funding?symbol=BTCUSDT
 
 t(:market_para_records)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpPreFunding>/private/linear/funding/prev-funding</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpPreFunding"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -1317,12 +1317,12 @@ curl https://api.bybit.com/private/linear/funding/predicted-funding?symbol=BTCUS
 
 t(:account_para_predictedFunding)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpPreFunding>/private/linear/funding/predicted-funding</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpPreFunding"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -1379,11 +1379,11 @@ GET
 
 t(:account_para_key)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oaApiKey>/open-api/api-key</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oaApiKey"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |

--- a/source/includes/linear_future/_api_data.md
+++ b/source/includes/linear_future/_api_data.md
@@ -22,12 +22,12 @@ curl https://api-testnet.bybit.com/v2/public/time
 ```
 t(:api_para_time)
 
-#### t(:httprequest_api_data)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpTime>/v2/public/time</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpTime"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_api_data)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 
@@ -55,11 +55,11 @@ GET
 
 t(:api_para_announcement)
 
-#### t(:httprequest_api_data)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpAnnouncement>/v2/public/announcement</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpAnnouncement"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_api_data)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |

--- a/source/includes/linear_future/_market_data.md
+++ b/source/includes/linear_future/_market_data.md
@@ -45,12 +45,12 @@ curl https://api.bybit.com/public/linear/kline?symbol=BTCUSDT&interval=1&limit=2
 
 t(:linear_market_para_querykline)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpSymbols>/public/linear/kline</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpSymbols"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -102,12 +102,12 @@ curl https://api.bybit.com/public/linear/recent-trading-records?symbol=BTCUSDT&l
 
 t(:market_para_records)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpRecentTradingRecords>/public/linear/recent-trading-records</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpRecentTradingRecords"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -145,12 +145,12 @@ curl https://api.bybit.com/public/linear/funding/prev-funding-rate?symbol=BTCUSD
 
 t(:market_para_records)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpPreFundingRate>/public/linear/funding/prev-funding-rate</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpPreFundingRate"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -210,12 +210,12 @@ curl https://api.bybit.com/public/linear/mark-price-kline?symbol=BTCUSDT&interva
 
 t(:linear_query_mark_price_kline)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=plmpk>/public/linear/mark-price-kline</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#plmpk"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -278,12 +278,12 @@ t(:market_para_orderbook)
 t(:market_aside_orderbook)
 </aside>
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpoL2>/v2/public/orderBook/L2</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpoL2"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |true |string |t(:row_comment_symbol) |
@@ -362,12 +362,12 @@ curl https://api-testnet.bybit.com/v2/public/tickers
 
 t(:market_para_symbol)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpTickers>/v2/public/tickers</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpTickers"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#symbol-symbol">symbol</a> |false |string |t(:row_comment_symbol) |
@@ -430,12 +430,12 @@ curl https://api.bybit.com/public/linear/symbols
 
 t(:market_para_querySymbol)
 
-#### t(:httprequest)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpSymbols>/public/linear/symbols</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpSymbols"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters)
+<p class="fake_header">t(:requestparameters)</p>
 |parameter|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 -->

--- a/source/includes/linear_future/_market_data.md
+++ b/source/includes/linear_future/_market_data.md
@@ -43,7 +43,7 @@ curl https://api.bybit.com/public/linear/kline?symbol=BTCUSDT&interval=1&limit=2
 }
 ```
 
-t(:market_para_querykline)
+t(:linear_market_para_querykline)
 
 #### t(:httprequest)
 GET

--- a/source/includes/linear_future/_wallet_data.md
+++ b/source/includes/linear_future/_wallet_data.md
@@ -52,12 +52,12 @@ t(:wallet_para_walletBalance)
 t(:wallet_aside_walletBalance)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpwBalance>/v2/private/wallet/balance</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpwBalance"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |<a href="#currency-currency-coin">coin</a> |true |string |t(:row_comment_coin) |
@@ -115,12 +115,12 @@ t(:wallet_para_walletRecords)
 t(:wallet_aside_walletRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawfRecords>/open-api/wallet/fund/records</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawfRecords"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |start_date |false |string |t(:row_comment_startDate) |
@@ -170,12 +170,12 @@ t(:wallet_para_withdrawRecords)
 t(:wallet_aside_withdrawRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawwList>/open-api/wallet/withdraw/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#oawwList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |start_date |false |string |t(:row_comment_startDate) |
@@ -236,12 +236,12 @@ t(:wallet_para_tradeRecords)
 t(:wallet_aside_tradeRecords)
 </aside>
 
-#### t(:httprequest_wallet)
+<p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpeList>/v2/private/execution/list</span></code>
 <button class="clipboard_button" data-clipboard-action="copy" data-clipboard-target="#vpeList"><img src="/images/copy_to_clipboard.png" height=15 width=15></img></button>
 
-#### t(:requestparameters_wallet)
+<p class="fake_header">t(:requestparameters)</p>
 |t(:column_parameter)|t(:column_required)|t(:column_type)|t(:column_comments)|
 |:----- |:-------|:-----|----- |
 |order_id |false |string |t(:wallet_row_comment_orderId) |

--- a/source/stylesheets/screen.css.scss
+++ b/source/stylesheets/screen.css.scss
@@ -783,3 +783,14 @@ html, body {
   visibility: visible;
   opacity: 1;
 }
+
+// fake header to address issue where code pushes HTTP Req down the page
+.fake_header {
+  @extend %header-font;
+  font-size: 16px;
+  margin-top: 2em !important;
+  margin-bottom: 1em;
+  padding-top: 1.2em;
+  padding-bottom: 1.2em;
+  background-image: linear-gradient(to bottom, rgba(#fff, 0.2), rgba(#fff, 0));
+}


### PR DESCRIPTION
Fixes doc layout so that code in the right panel does not push the HTTP Request & Request Parameters h4 headers down the webpage.

The `fake_header` class in screen.css.scss looks identical to the h4 it replaces, with the benefit that it does not div the page.