### PR TITLE
Revert "add notice for USDT in walletrecords"

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -389,7 +389,6 @@ en:
   wallet_para_walletRecords: Get wallet fund records. This endpoint also shows exchanges from the <a href="https://testnet.bybit.com/app/assets/assets-exchange">Asset Exchange</a>, where the <code>type</code>s for the exchange are <code>ExchangeOrderWithdraw</code> and <code>ExchangeOrderDeposit</code>.
   wallet_aside_walletRecords: |
     Find more detail for types <code>Withdraw</code> and <code>Refund</code> in the <a href="#t-withdrawrecords">Withdraw Records</a> endpoint.
-  wallet_aside_walletRecords1: USDT records will not be returned unless you pass <code>USDT</code> with the <code>coin</code> parameter.
   ### Withdraw Records
   withdrawrecords: Withdraw Records
   wallet_para_withdrawRecords: Get withdrawal records.

--- a/source/includes/inverse_future/_wallet_data.md
+++ b/source/includes/inverse_future/_wallet_data.md
@@ -115,10 +115,6 @@ t(:wallet_para_walletRecords)
 t(:wallet_aside_walletRecords)
 </aside>
 
-<aside class="notice">
-t(:wallet_aside_walletRecords1)
-</aside>
-
 <p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=oawfRecords>/open-api/wallet/fund/records</span></code>


### PR DESCRIPTION
Mistakenly added a warning for wallet records which will no longer apply for the next release - this PR corrects this.