### PR TITLE
fix real time query stop order return order_id instead of stop_order_id

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -641,7 +641,7 @@ en:
   ### Query Conditional Order (real-time)
   querycond: Query Conditional Order (real-time)
   account_para_queryConditional: Query real-time stop order information. When passing the parameter <code>order_id</code> or <code>order_link_id</code>, a single order data will be returned; If the parameters <code>order_id</code> and <code>order_link_id</code> are not passed, <b>return multiple unfilled orders,max size is 50</b>.
-
+  account_para_queryConditionalNote: <b>When stop-order triggered, it becomes an active order within the system. in fact, returns <code>order_id</code> in the structure equal to <code>stop_order_id</code> of the request parameter</b>
 
   ## Leverage
   leverage: Leverage

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -641,7 +641,7 @@ en:
   ### Query Conditional Order (real-time)
   querycond: Query Conditional Order (real-time)
   account_para_queryConditional: Query real-time stop order information. When passing the parameter <code>order_id</code> or <code>order_link_id</code>, a single order data will be returned; If the parameters <code>order_id</code> and <code>order_link_id</code> are not passed, <b>return multiple unfilled orders,max size is 50</b>.
-  account_para_queryConditionalNote: <b>When stop-order triggered, it becomes an active order within the system. in fact, returns <code>order_id</code> in the structure equal to <code>stop_order_id</code> of the request parameter</b>
+  account_para_queryConditionalNote: <b>When a stop order is triggered, it becomes an active order within the system. This endpoint returns <code>order_id</code> which is equal to <code>stop_order_id</code> request parameter.</b>
 
   ## Leverage
   leverage: Leverage

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -619,6 +619,7 @@ zh-cn:
   ### Query Conditional Order (real-time)
   querycond: 实时查询条件委托
   account_para_queryConditional: 实时查询条件委托。当传递参数<code>order_id</code>或<code>order_link_id</code>其中任意一个时，将返回单条订单数据；如果参数<code>order_id</code>和<code>order_link_id</code>都不传递时，将返回所有<b>未成交</b>的订单，最多50条。
+  account_para_queryConditionalNote: <b>条件单触发后，在系统内部会成为活动单，实际上，返回结构体中的<code>order_id</code>等同于请求参数的<code>stop_order_id</code></b>
 
   ## Leverage
   leverage: 用户杠杆

--- a/source/includes/inverse_future/_account_data.md
+++ b/source/includes/inverse_future/_account_data.md
@@ -985,6 +985,8 @@ curl "https://api.bybit.com/v2/private/stop-order?api_key={api_key}&symbol=BTCUS
 <!--
 t(:account_para_queryConditional)
 -->
+t(:account_para_queryConditionalNote)
+
 <p class="fake_header">t(:httprequest)</p>
 GET
 <code><span id=vpStopOrder>/v2/private/stop-order</span></code>

--- a/source/includes/inverse_future/_account_data.md
+++ b/source/includes/inverse_future/_account_data.md
@@ -122,7 +122,7 @@ print(client.Order.Order_getOrders(symbol="BTCUSD",order_status="PendingCancel")
     "ext_code": "",
     "ext_info": "",
     "result": {
-        "data": [ 
+        "data": [
             {
                 "user_id": 160861,
                 "order_status": "Cancelled",
@@ -985,7 +985,9 @@ curl "https://api.bybit.com/v2/private/stop-order?api_key={api_key}&symbol=BTCUS
 <!--
 t(:account_para_queryConditional)
 -->
+<aside class="notice">
 t(:account_para_queryConditionalNote)
+</aside>
 
 <p class="fake_header">t(:httprequest)</p>
 GET


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->