### PR TITLE
fix spot account available balance describe

### DIFF
--- a/locales/en.yml
+++ b/locales/en.yml
@@ -2089,6 +2089,7 @@ en:
   spotLow: Low price
   spot_total: Total equity
   spot_fees: Trading fee
+  spot_account_free: Available balance
   spotClose: Close price
   spotVolume: Trading volume
   spotTrades: Number of trades

--- a/locales/zh-cn.yml
+++ b/locales/zh-cn.yml
@@ -1968,6 +1968,7 @@ zh-cn:
   spot_token: 币种
   spot_total: 总额
   spot_fees: 手续费
+  spot_account_free: 可用余额
   spot_fee: 手续费
   spot_fee_symbol: 手续费币种
   spot_locked: 冻结余额

--- a/source/includes/spot/_wallet_data.md
+++ b/source/includes/spot/_wallet_data.md
@@ -25,7 +25,7 @@ t(:wallet_para)
                 "coinId": "USDT",
                 "coinName": "USDT",
                 "total": "10",
-                "fee": "10",
+                "free": "10",
                 "locked": "0"
             }
         ]
@@ -51,5 +51,5 @@ GET
 |coinId| string | t(:spot_token)|
 |coinName| string | t(:spot_token)|
 |total| string | t(:spot_total)|
-|fee| float| t(:spot_fees)|
+|free| float| t(:spot_account_free)|
 |locked| float | t(:spot_locked)


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "slatedocs/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->
modify spot /spot/v1/account Response fee -> free. It means available balance replace trade fee