### PR TITLE
.gitignore: update to include vim's swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ ubuntu-*-console.log
 
 # vendor
 vendor
+
+# vim's swap files
+*.swp
+*.swo


### PR DESCRIPTION
Not to go overboard to use general case of patterns
like `*.sw?` because `.svg` or other unexpected files'
extensions might get excluded. But almost mostly
only `.swp` and `.swo` are more than enough.


