### PR TITLE
Missing semicolon added

### DIFF
--- a/source/includes/linear_perpetual/_account_data.md
+++ b/source/includes/linear_perpetual/_account_data.md
@@ -628,7 +628,7 @@ print(session_auth.place_conditional_order(
     base_price=16100,
     stop_px=8150,
     time_in_force="GoodTillCancel",
-    trigger_by="LastPrice"
+    trigger_by="LastPrice",
     order_link_id="cus_order_id_1",
     reduce_only=False,
     close_on_trigger=False


### PR DESCRIPTION
Semicolon is missing in the python example code for conditional order